### PR TITLE
feat: 在 macOS 上隐藏 dock 图标，设置为菜单栏/托盘应用

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -664,6 +664,10 @@ pub fn run() {
         .setup(|app| {
             let handle = app.handle().clone();
 
+            // Hide dock icon on macOS (menu bar / tray-only app)
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+
             // Load config
             let config = load_config(&handle);
             {


### PR DESCRIPTION
在 macOS 上隐藏 dock 图标，设置为菜单栏/托盘应用